### PR TITLE
fix: correct type of "spaces" option

### DIFF
--- a/packages/sort-jsonc/src/sortJsonc.ts
+++ b/packages/sort-jsonc/src/sortJsonc.ts
@@ -17,7 +17,7 @@ export type SortJsoncOptions = {
    * Number of spaces to indent the JSON.
    * Same as the second parameter of {@link JSON.stringify()}.
    */
-  spaces?: number | undefined | null;
+  spaces?: string | number | undefined | null;
 
   /**
    * Reviver function like the second parameter of {@link JSON.parse()}.


### PR DESCRIPTION
The JSON.stringify function accepts a string as an argument to `stringify`. This allows you to use tabs by passing `"\t"` in the `spaces param. This PR updates the typing of sort-jsonc's options to allow string.