### PR TITLE
fix: fix issues with `null` breaking sorting

### DIFF
--- a/.changeset/nine-moons-teach.md
+++ b/.changeset/nine-moons-teach.md
@@ -1,0 +1,5 @@
+---
+'sort-jsonc': patch
+---
+
+Fix issue with `null` values breaking sort.

--- a/packages/sort-jsonc/src/sortJsonc.ts
+++ b/packages/sort-jsonc/src/sortJsonc.ts
@@ -48,7 +48,7 @@ function getCompareFn(sortOption: SortJsoncOptions['sort']) {
   if (Array.isArray(sortOption)) {
     return createOrderCompareFn(sortOption);
   }
-  
+
   if (typeof sortOption === 'function') {
     return sortOption;
   }
@@ -81,11 +81,12 @@ export function sortDeepWithSymbols<T extends Record<string | symbol, any>>(init
     if (!Array.isArray(current)) {
       keys.sort(compareFn);
     }
+
     for (const key of keys) {
       const value = current[key];
       sorted[key] = value;
 
-      if (typeof value === 'object') {
+      if (typeof value === 'object' && value !== null) {
         stack.push([sorted, key]);
       }
     }


### PR DESCRIPTION
Fixes #1.

`typeof null` is `object` in JavaScript 🤪 so because of a bad check, `sort-jsonc` is trying to sort null values (as it identifies them as objects).

This PR should fix this issue.
