### PR TITLE
feat(sort-jsonc): New function: isSortedJsonc() checks if a JSON/JSONC/JSON5 string is sorted

### DIFF
--- a/.changeset/thin-steaks-protect.md
+++ b/.changeset/thin-steaks-protect.md
@@ -1,0 +1,9 @@
+---
+"sort-jsonc": minor
+---
+
+New function: isSortedJsonc() checks if a JSON/JSONC/JSON5 string is sorted
+
+The new function isSortedJsonc can be used to check if a JSON/JSONC/JSON5 string is sorted. The implementation
+short-circuits as soon as an unsorted element is found. Custom sort functions and order arrays can be provided to
+customize the sort logic.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "command": "pnpm test",
+      "name": "Run pnpm test",
+      "request": "launch",
+      "type": "node-terminal",
+      "cwd": "${workspaceFolder}/packages/sort-jsonc"
+    },
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+	"typescript.tsdk": "node_modules/typescript/lib",
+	"editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/packages/sort-jsonc/package.json
+++ b/packages/sort-jsonc/package.json
@@ -31,7 +31,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "prepublish": "npm run build",
-    "test": "vitest",
+    "test": "vitest --run",
     "lint": "biome check src",
     "lint:apply": "biome check src --apply"
   },

--- a/packages/sort-jsonc/src/index.ts
+++ b/packages/sort-jsonc/src/index.ts
@@ -1,1 +1,1 @@
-export { sortJsonc, type CompareFn, type SortJsoncOptions } from './sortJsonc';
+export { sortJsonc, isSortedJsonc, type CompareFn, type SortJsoncOptions } from './sortJsonc';

--- a/packages/sort-jsonc/src/sortJsonc.test.ts
+++ b/packages/sort-jsonc/src/sortJsonc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sortJsonc } from './sortJsonc';
+import { isSortedJsonc, sortJsonc } from './sortJsonc';
 
 describe('sortJsonc', () => {
   it('sorts a .jsonc string and preserves comments', () => {
@@ -223,6 +223,164 @@ describe('sortJsonc', () => {
 }
   `.trim()
       );
+    });
+  });
+});
+
+describe('isSortedJsonc', () => {
+  const unsortedString = `
+{
+  /* comment above h */ 
+  "h": 8,
+  "c": 3, // comment after c
+  "a": 1,
+  "d": {
+    // in d above f,
+    "f": 6,
+    "e": 5,
+  },
+  "i": {
+    "k": 11,
+    /**
+     * block comment above j
+     */
+    "j": 10,
+    "l": {
+      "m": {
+        "p": 16,
+        "o": 15,
+        "n": 14
+      }
+    }
+  },
+  "g": 7,
+  // above b
+  "b": 2,
+}`;
+
+  const sortedString = `
+{
+  "a": 1,
+  // above b
+  "b": 2,
+  "c": 3, // comment after c
+  "d": {
+    "e": 5,
+    // in d above f,
+    "f": 6
+  },
+  "g": 7,
+  /* comment above h */
+  "h": 8,
+  "i": {
+    /**
+     * block comment above j
+     */
+    "j": 10,
+    "k": 11,
+    "l": {
+      "m": {
+        "n": 14,
+        "o": 15,
+        "p": 16
+      }
+    }
+  }
+}`;
+
+  it('sorted input returns true', () => {
+    const result = isSortedJsonc(sortedString);
+
+    expect(result).to.be.true;
+  });
+
+  it('unsorted input returns false', () => {
+    const result = isSortedJsonc(unsortedString);
+
+    expect(result).to.be.false;
+  });
+
+  it('checks unsorted nested arrays', () => {
+    const jsoncString = `
+{
+  "k": 11,
+  "a": [
+    {
+      "c": 3,
+      "b": 2
+    },
+    {
+      "e": 5,
+      "d": 4,
+      "f": [
+        {
+          "h": 8,
+          "g": 7
+        },
+        // array comment!
+        {
+          "j": 10,
+          "i": 9
+        }
+      ]
+    }
+  ]
+}
+    `;
+
+    const result = isSortedJsonc(jsoncString);
+
+    expect(result).to.be.false;
+  });
+
+  describe('order sort', () => {
+    const sortedString = `
+{
+  // Specify the base directory to resolve non-relative module names.
+  "baseUrl": ".",
+  // Generate .d.ts files from TypeScript and JavaScript files in your project.
+  "declaration": true,
+  // Create sourcemaps for d.ts files.
+  "declarationMap": true,
+  // Ensure 'use strict' is always emitted.
+  "alwaysStrict": true,
+  // Disable error reporting for unreachable code.
+  "allowUnreachableCode": false,
+  // Enable error reporting in type-checked JavaScript files.
+  "checkJs": false
+}
+      `;
+
+    const unsortedString = `
+{
+  // Ensure 'use strict' is always emitted.
+  "alwaysStrict": true,
+  // Disable error reporting for unreachable code.
+  "allowUnreachableCode": false,
+  // Specify the base directory to resolve non-relative module names.
+  "baseUrl": ".",
+  // Enable error reporting in type-checked JavaScript files.
+  "checkJs": false,
+  // Generate .d.ts files from TypeScript and JavaScript files in your project.
+  "declaration": true,
+  // Create sourcemaps for d.ts files.
+  "declarationMap": true
+}
+      `;
+    it('sorted input returns true', () => {
+      const result = isSortedJsonc(sortedString, {
+        sort: ['baseUrl', 'declaration', 'declarationMap', 'alwaysStrict', 'allowUnreachableCode', 'checkJs'],
+      });
+
+      expect(result).to.be.true;
+    });
+
+    it('unsorted input returns false', () => {
+      const result = isSortedJsonc(unsortedString, {
+        sort: ['baseUrl', 'declaration', 'declarationMap', 'alwaysStrict', 'allowUnreachableCode', 'checkJs'],
+      });
+
+      expect(result).to.be.false;
     });
   });
 });

--- a/packages/sort-jsonc/src/sortJsonc.ts
+++ b/packages/sort-jsonc/src/sortJsonc.ts
@@ -106,10 +106,12 @@ export function sortDeepWithSymbols<T extends Record<string | symbol, any>>(
 
     if (!Array.isArray(current)) {
       alreadySorted = isSortedArray(keys, compareFn);
-      if (checkOnly) {
-        return alreadySorted;
-      }
+
       if (!alreadySorted) {
+      	if (checkOnly) {
+      	  return false
+      	}
+
         keys.sort(compareFn);
       }
     }

--- a/packages/sort-jsonc/src/sortJsonc.ts
+++ b/packages/sort-jsonc/src/sortJsonc.ts
@@ -105,7 +105,7 @@ export function sortDeepWithSymbols<T extends Record<string | symbol, any>>(
     }
 
     if (!Array.isArray(current)) {
-      alreadySorted = isSorted(keys, compareFn);
+      alreadySorted = isSortedArray(keys, compareFn);
       if (checkOnly) {
         return alreadySorted;
       }
@@ -170,7 +170,7 @@ export function isSortedJsonc(jsoncString: string, options?: Pick<SortJsoncOptio
  * @param compareFn - a compare function to use for the comparison.
  * @returns true if the array is sorted, false otherwise.
  */
-function isSorted<T extends string>(arr: T[], compareFn: CompareFn): boolean {
+function isSortedArray<T extends string>(arr: T[], compareFn: CompareFn): boolean {
   return (
     arr
       // This creates a copy of the array that we will iterate over.

--- a/packages/sort-jsonc/src/sortJsonc.ts
+++ b/packages/sort-jsonc/src/sortJsonc.ts
@@ -68,8 +68,8 @@ function getCompareFn(sortOption: SortJsoncOptions['sort']) {
  *          - `sorted`: The sorted object.
  *          - `alreadySorted`: A boolean indicating whether the object was already sorted.
  *
- * @template T - The type of the object to be sorted or checked. Must extend `Record<string | symbol, any>`.
- * @template C - The conditional type that extends boolean, representing the `checkOnly` parameter.
+ * @typeParam T - The type of the object to be sorted or checked. Must extend `Record<string | symbol, any>`.
+ * @typeParam C - The conditional type that extends boolean, representing the `checkOnly` parameter.
  */
 export function sortDeepWithSymbols<T extends Record<string | symbol, any>, C extends boolean>(
   initial: T,


### PR DESCRIPTION
Fixes #6 

Adds a new exported function, `isSortedJsonc` that can be used to check if a JSON/JSONC/JSON5 string is sorted. The implementation short-circuits as soon as an unsorted element is found.

I changed the internal `sortDeepWithSymbols` function to accept a new parameter, checkOnly, and shortcircuits when that parameter is passed. The typing is configured so that when `checkOnly` is true, the function returns a boolean. Otherwise, it returns an object like `{ sorted, alreadySorted: boolean }`. The `alreadySorted` return value is unused, but it seemed possibly useful, so I left it. I can remove it if desired.

Also added an internal `isSortedArray` function to check if an array is sorted with a short-circuit.

There were no changes to any public APIs except the newly added one, so I added a minor version changeset.